### PR TITLE
Add Room-style configuration methods with backward compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ refs. https://developer.android.com/training/data-storage/room/migrating-db-vers
 3. Configure the plugin in your `build.gradle.kts`:
 ```kotlin
 roomSchemaDocs {
-    schemaDir = "$projectDir/schemas"
-    outputDir = "$projectDir/schemas-docs"
+    schemaDirectory("$projectDir/schemas")
+    outputDirectory("$projectDir/schemas-docs")
 }
 ```
 

--- a/plugin/src/main/kotlin/jp/ntsk/room/schema/docs/plugin/RoomSchemaDocsPlugin.kt
+++ b/plugin/src/main/kotlin/jp/ntsk/room/schema/docs/plugin/RoomSchemaDocsPlugin.kt
@@ -16,11 +16,11 @@ class RoomSchemaDocsPlugin : Plugin<Project> {
             description = "Generate Mermaid ER diagrams from Room schema JSON files."
 
             doLast {
-                val schemaDir = File(extension.schemaDir)
-                val outputDir = File(extension.outputDir)
+                val schemaDir = File(extension.resolveSchemaDir())
+                val outputDir = File(extension.resolveOutputDir())
 
                 if (!schemaDir.exists()) {
-                    throw IllegalArgumentException("Schema directory does not exist: ${extension.schemaDir}")
+                    throw IllegalArgumentException("Schema directory does not exist: ${extension.resolveSchemaDir()}")
                 }
 
                 if (!outputDir.exists()) {
@@ -35,7 +35,7 @@ class RoomSchemaDocsPlugin : Plugin<Project> {
                     .toList()
 
                 if (jsonFiles.isEmpty()) {
-                    throw IllegalArgumentException("No schema files found in directory or subdirectories: ${extension.schemaDir}")
+                    throw IllegalArgumentException("No schema files found in directory or subdirectories: ${extension.resolveSchemaDir()}")
                 }
 
                 jsonFiles
@@ -58,6 +58,28 @@ class RoomSchemaDocsPlugin : Plugin<Project> {
 }
 
 open class RoomSchemaDocsExtension {
+    @Deprecated("Use schemaDirectory() method instead", ReplaceWith("schemaDirectory(value)"))
     var schemaDir: String = "schemas"
+
+    @Deprecated("Use outputDirectory() method instead", ReplaceWith("outputDirectory(value)"))
     var outputDir: String = "docs"
+
+    private var schemaDirectoryValue: String? = null
+    private var outputDirectoryValue: String? = null
+
+    fun schemaDirectory(path: String) {
+        schemaDirectoryValue = path
+    }
+
+    fun outputDirectory(path: String) {
+        outputDirectoryValue = path
+    }
+
+    internal fun resolveSchemaDir(): String {
+        return schemaDirectoryValue ?: schemaDir
+    }
+
+    internal fun resolveOutputDir(): String {
+        return outputDirectoryValue ?: outputDir
+    }
 }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -89,6 +89,6 @@ room {
 }
 
 roomSchemaDocs {
-    schemaDir = "$projectDir/schemas"
-    outputDir = "$projectDir/schemas-docs"
+    schemaDirectory("$projectDir/schemas")
+    outputDirectory("$projectDir/schemas-docs")
 }


### PR DESCRIPTION
- Add schemaDirectory() and outputDirectory() methods matching Room plugin API
- Maintain backward compatibility with existing schemaDir/outputDir properties
- Mark old properties as `@Deprecated` with replacement suggestions
- New methods take precedence over property-based configuration
- Update README.md to show recommended Room-style configuration